### PR TITLE
Add an option to use the consolidated client websocket

### DIFF
--- a/cfg/endpoints.js
+++ b/cfg/endpoints.js
@@ -5,6 +5,8 @@ export const SERVICE_HOSTNAME = 'api.trellus.ai'
 // realtime endpoints
 export const SUBSCRIBE_TRANSCRIPT_ENDPOINT = 'subscribe-transcript';
 export const SUBSCRIBE_COACHING_ENDPOINT = 'subscribe-coaching';
+export const SUBSCRIBE_CLIENT_ENDPOINT = 'subscribe-client';
+
 export const SIGNUP_USER_ENDPOINT = 'signup-user'
 
 // extension ID

--- a/lib/app/coaching-manager.js
+++ b/lib/app/coaching-manager.js
@@ -9,6 +9,7 @@ import {CLOSED, DISABLED, MIN_TO_SEC, SEC_TO_MS} from '../../cfg/const.js';
 import {
   SUBSCRIBE_COACHING_ENDPOINT,
   SUBSCRIBE_TRANSCRIPT_ENDPOINT,
+  SUBSCRIBE_CLIENT_ENDPOINT,
 } from '../../cfg/endpoints.js';
 import { generateColor } from '../graphics.js'
 import { createLoggingWebsocketPromise } from '../network.js';
@@ -18,13 +19,15 @@ import { durationToString } from '../time-fns.js';
 
 
 export class CoachingManager {
-  constructor(sessionIdentifiers, demoMode=false, forceRealtimeHostname=null) {
+  constructor (sessionIdentifiers, demoMode=false, consolidatedEndpoint=false) {
     // track requests from extension to use demo mode or force realtime hosts
     this._demoMode = demoMode
-    this._forceRealtimeHostname = forceRealtimeHostname
 
-    // track state per conversation: websocket for coaching, and dom elements per party
+    // session websockets
+    this._consolidatedEndpoint = consolidatedEndpoint
+    this._clientSocket = null;
     this.coachingSocket = null;
+    this.transcriptSocket = null
 
     // keep track of the current shown behavioral prompt
     this._activePrompt = null;
@@ -35,7 +38,6 @@ export class CoachingManager {
     this._updateHeight = 500
 
     // keep track of transcripts
-    this.transcriptSocket = null
     this._transcripts = []
     this._partyCodeToColor = {}
 
@@ -131,16 +133,22 @@ export class CoachingManager {
    */
   async start(session) {
     console.log(`[Trellus][iframe] Starting session ${session.session_id}`)
-    if (this.coachingSocket || this.transcriptSocket)
+    if (this.coachingSocket || this.transcriptSocket || this._clientSocket)
       throw new Error(`Close existing connection before starting a new one`)
-    this.coachingSocket = await this.connectCoachingSocket(session)
-    this.transcriptSocket = await this.connectTranscriptSocket(session)
+    if (this._consolidatedEndpoint) {
+      this._clientSocket = await this._connectClientSocket(session)
+    } else {
+      this.coachingSocket = await this.connectCoachingSocket(session)
+      this.transcriptSocket = await this.connectTranscriptSocket(session)
+    }
     this._partyToSummary = new Map();
   }
 
   closeSockets() {
+    if (this._clientSocket) this._clientSocket.close()
     if (this.coachingSocket) this.coachingSocket.close()
     if (this.transcriptSocket) this.transcriptSocket.close()
+    this._clientSocket = null
     this.coachingSocket = null
     this.transcriptSocket = null
     this._partyToSummary = null
@@ -173,10 +181,9 @@ export class CoachingManager {
 
   /**
    * Add transript to display
-   * @param {String} data Transcript object to add
+   * @param {Object} transcript Transcript object to add
    */
-  _updateTranscript (data) {
-    const transcript = JSON.parse(data)
+  _updateTranscript (transcript) {
     console.log(`[Trellus][iframe] Transcript from ${transcript['person_name']} (${transcript['party_code']}). Text: "${transcript['text']}"`)
     // get party code and name
     const partyCode = transcript['party_code']
@@ -242,9 +249,9 @@ export class CoachingManager {
   async connectTranscriptSocket(session) {
     const queryParams = { 'session_id': session['session_id'] }
     const queryString = new URLSearchParams(queryParams).toString()
-    const hostname = this._forceRealtimeHostname ?? session['realtime_hostname']
-    const socketUrl = `wss://${hostname}/${SUBSCRIBE_TRANSCRIPT_ENDPOINT}?${queryString}`
-    return await createLoggingWebsocketPromise('transcriptSocket', socketUrl, this._updateTranscript.bind(this))
+    const socketUrl = `wss://${session['realtime_hostname']}/${SUBSCRIBE_TRANSCRIPT_ENDPOINT}?${queryString}`
+    const callback = (data) => this._updateTranscript(JSON.parse(data))
+    return await createLoggingWebsocketPromise('transcriptSocket', socketUrl, callback)
   }
 
   /**
@@ -254,9 +261,28 @@ export class CoachingManager {
   async connectCoachingSocket(session) {
     const queryParams = { 'session_id': session['session_id']}
     const queryString = new URLSearchParams(queryParams).toString()
-    const hostname = this._forceRealtimeHostname ?? session['realtime_hostname']
-    const socketUrl = `wss://${hostname}/${SUBSCRIBE_COACHING_ENDPOINT}?${queryString}`
-    return await createLoggingWebsocketPromise('coachingSocket', socketUrl, this._updateCoachingData.bind(this))
+    const socketUrl = `wss://${session['realtime_hostname']}/${SUBSCRIBE_COACHING_ENDPOINT}?${queryString}`
+    const callback = (data) => this._updateCoachingData(JSON.parse(data))
+    return await createLoggingWebsocketPromise('coachingSocket', socketUrl, callback)
+  }
+
+  /**
+   * Create a WebSocket to receive coaching related data
+   * @param {Object} session
+   */
+   async _connectClientSocket(session) {
+    const queryString = new URLSearchParams({'session_id': session['session_id']}).toString()
+    const socketUrl = `wss://${session['realtime_hostname']}/${SUBSCRIBE_CLIENT_ENDPOINT}?${queryString}`
+    const callback = (dataString) => {
+      const data = JSON.parse(dataString)
+      if (data['transcript_data'] != null) 
+        this._updateTranscript(data['transcript_data'])
+      else if (data['coaching_data'] != null)
+        this._updateCoachingData(data['coaching_data'])
+      else if (data['weather_data'] != null)
+        console.log(`Weather data ${JSON.stringify(data['weather_data'])}`) // todo: display this
+    }
+    return await createLoggingWebsocketPromise('clientSocket', socketUrl, callback)
   }
 
   /**
@@ -387,7 +413,7 @@ export class CoachingManager {
    * @param {Array.<Object>} data Summary data
    */
   _updateSummary (data) {
-    if (Object.keys(this._partyToSummary).length === 0) {
+    if (this._partyToSummary.size === 0) {
       console.log('[Trellus][Iframe] Sending coaching loaded to coaching UI')
       window.parent.postMessage({"type": "coachingLoaded"}, '*'); // only load on receiving first summary
     }
@@ -486,13 +512,11 @@ export class CoachingManager {
   }
 
   /**
-   * Update real-time coaching based on `string` recieved over the websocket
-   * @param {String} string
+   * Update real-time coaching based on `data` recieved over the websocket
+   * @param {Object} data
    * @returns
    */
-  _updateCoachingData(string) {
-    const data = JSON.parse(string)
-
+  _updateCoachingData(data) {
     // case 1: coaching data is sent as an array
     if (Array.isArray(data))
       return data.forEach((x) => this._updateCoaching(x))

--- a/pages/coaching/index.js
+++ b/pages/coaching/index.js
@@ -12,7 +12,7 @@ function receiveMessage (event) {
     const procedure = data['type']
     if (procedure === 'sessionInformation') {
         const session = data['session']
-        window._coachingSession = new CoachingManager(session, data['demoMode'], data['forceRealtimeHostname'])
+        window._coachingSession = new CoachingManager(session, data['demoMode'], data['consolidatedEndpoint'])
     } else if (procedure === 'stopDrag') {
         document.querySelector('.trellus-transcript-box').classList.remove(DISABLED)
         document.querySelector('.trellus-main').classList.remove(DISABLED)


### PR DESCRIPTION
This PR connects to the new `subscribe-coaching` endpoint based on a boolean parameter (`consolidatedEndpoint`) the extension can pass through to the iframe along with session information.

At some point in the future, we will move everyone off the old subscribe-transcript and subscribe-coachign endpoints and depricate that code.