### PR TITLE
Put logo back in coaching slider.

### DIFF
--- a/pages/live/live.css
+++ b/pages/live/live.css
@@ -532,7 +532,7 @@ initial-value: 0;
     left: 2px;
     bottom: 3px;
     background-color: black;
-    background-image: url(../images/logo.png);
+    background-image: url(../../images/logo.png);
     background-repeat: no-repeat;
     background-size: 20px;
     background-origin: content-box;


### PR DESCRIPTION
We were 404ing it out. CSS URLs interpret relative paths from the stylesheet file, rather than from the page they're used from:

https://developer.mozilla.org/en-US/docs/Web/CSS/url

Before | After
---|---
![before](https://user-images.githubusercontent.com/380280/196771175-ab64f19e-d9de-4a8b-a0c9-f11c7d33df2b.png) | ![after](https://user-images.githubusercontent.com/380280/196771172-8688a66a-967a-43a5-bae5-e75a7db009bd.png)
