### PR TITLE
Add "Click to request AI summary" button.

### DIFF
--- a/cfg/endpoints.js
+++ b/cfg/endpoints.js
@@ -15,6 +15,7 @@ export const SAVE_USER_TRIGGERS_ENDPOINT = 'save-user-triggers'
 export const LIST_USER_SESSIONS_ENDPOINT = 'list-user-sessions'
 export const GET_SESSION_DATA_ENDPOINT = 'get-session-data'
 export const SUBMIT_TRACKER = 'submit-tracker'
+export const REQUEST_TEXT_SUMMARY_ENDPOINT = 'request-text-summary'
 
 // extension ID
 export const EXTENSION_ID = "enhpjjojmnlnaokmppkkifgaonfojigl"

--- a/lib/app/services.js
+++ b/lib/app/services.js
@@ -1,6 +1,6 @@
 import { MS_TO_MICRO } from "../../cfg/const.js"
 import { TRELLUS_NOTE_SOURCE } from "../../cfg/endpoints.js"
-import { GET_SESSION_DATA_ENDPOINT, GET_USER_TRIGGERS_ENDPOINT, LIST_USER_SESSIONS_ENDPOINT, SAVE_USER_TRIGGERS_ENDPOINT, SERVICE_HOSTNAME, SUBMIT_NOTES_ENDPOINT, UPDATE_DISPLAY_ENDPOINT } from "../../cfg/endpoints.js"
+import { GET_SESSION_DATA_ENDPOINT, GET_USER_TRIGGERS_ENDPOINT, LIST_USER_SESSIONS_ENDPOINT, SAVE_USER_TRIGGERS_ENDPOINT, SERVICE_HOSTNAME, SUBMIT_NOTES_ENDPOINT, UPDATE_DISPLAY_ENDPOINT, REQUEST_TEXT_SUMMARY_ENDPOINT } from "../../cfg/endpoints.js"
 import { simpleFetchAndCheck } from "../network.js"
 
 /**
@@ -79,4 +79,17 @@ export async function submitNotes (apiKey, sessionId, dispositions=[], notes="")
   const parameters = {'api_key': apiKey, 'dispositions': dispositions, 
   'session_id': sessionId, 'notes': notes, 'note_source': TRELLUS_NOTE_SOURCE}
   await simpleFetchAndCheck(endpoint, parameters, true)
+}
+
+/**
+ * Request a text summary for `sessionId`
+ * @param {String} apiKey
+ * @param {String} sessionId
+ * @param {String|null} forceServiceHostname
+ */
+export async function requestTextSummary (apiKey, sessionId, forceServiceHostname=null) {
+  const hostname = forceServiceHostname ?? SERVICE_HOSTNAME
+  const url = `https://${hostname}/${REQUEST_TEXT_SUMMARY_ENDPOINT}`
+  const parameters = {'session_id': sessionId, 'api_key': apiKey}
+  return await simpleFetchAndCheck(url, parameters, true)
 }

--- a/pages/live/index.html
+++ b/pages/live/index.html
@@ -112,6 +112,7 @@
                     <a href="https://app.trellus.ai/pages/react-app/#/history" target="_blank" style="text-decoration:none;"><div class="header-click-text">Click for past transcripts</div></a>
                 </div>
                 <div class="panel-body" id="transcript-panel-inner">
+                    <button type="button" id="auto-summary-request-button" class="new-feature" style="display: none;">Click to request AI summary</button>
                     <div class="trellus-recording-footer">
                         <div class="trellus-summary" id="trellus-summary"></div>
                     </div>

--- a/pages/live/live.css
+++ b/pages/live/live.css
@@ -593,7 +593,7 @@ border-radius: 50%;
     visibility: visible;
 }
 
-.copy-button:hover {
+button:hover {
     cursor: pointer;
     color: #5DD077;
 }
@@ -656,13 +656,25 @@ border-radius: 50%;
     font-size: x-large; 
 }
 
-.new-feature-flag {
+.new-feature {
+    /*
+    The "New!" will only appear in the right place if `position` is anything
+    other than `static`. So use .new-feature on elements without `position` set,
+    and .new-feature-positioned on an element with `position` set.
+    */
+    position: relative;
+}
+.new-feature:after, .new-feature-positioned:after {
     border-radius: 5px; 
-    font-size: smaller; 
+    font-size: 10px;
     background-color: #5DD077;
     height: fit-content; 
     padding: 2px; 
     color: white;
+    content: "New!";
+    position: absolute;
+    top: -5px;
+    right: -2em;
 }
 
 .star-div {


### PR DESCRIPTION
The button shows up if the coaching page receives a notification that a text summary is not forthcoming. On clicking, the button disappears and hits /request-text-summary on the services server.

The prompt ID, session ID, and client ID are all cached on the button so that we can still record the Display of the summary---so effectively the summary's Display record steals the prompt ID of the TEXT_SUMMARY_PENDING=false message.

Switch `.copy-button:hover` to `button:hover` since the only two preexisting button elements were of `copy-button` class.

Revive the "New!" callout and use `:after` so that we can apply it to an element just by adding a css class.

Depends on https://github.com/cbonnoit/python/pull/514

![button](https://user-images.githubusercontent.com/380280/217713411-a15054a5-7c87-45d7-80ac-52cef490e765.png)
